### PR TITLE
updated *ngFor syntax that was changed in beta.17

### DIFF
--- a/src/toast-container.component.ts
+++ b/src/toast-container.component.ts
@@ -6,7 +6,7 @@ import {ToastOptions} from './toast-options';
   selector: 'toast-container',
   template: `
     <div id="toast-container" [style.position]="position" class="{{positionClass}}">
-      <div *ngFor="#toast of toasts" class="toast-{{toast.type}}" (click)="dismiss(toast)">
+      <div *ngFor="let toast of toasts" class="toast-{{toast.type}}" (click)="dismiss(toast)">
         <div *ngIf="toast.title" class="{{titleClass}}">{{toast.title}}</div>
         <div class="{{messageClass}}">{{toast.message}}</div>
       </div>


### PR DESCRIPTION
Updated the *ngFor syntax. See: https://github.com/angular/angular/blob/master/CHANGELOG.md#200-beta17-2016-04-28. Gives console warning if we use the old syntax.