### PR TITLE
Remove .ts files from npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,9 +15,5 @@ demo
 demo-build
 webpack.config.js
 
-#typescript sources
-*.ts
-*.js.map
-!*.d.ts
-/components/**/*.ts
-!/components/**/*.d.ts
+#typescript sourcesc
+*.js.mapc

--- a/.npmignore
+++ b/.npmignore
@@ -15,5 +15,5 @@ demo
 demo-build
 webpack.config.js
 
-#typescript sourcesc
+#typescript sources
 *.js.map

--- a/.npmignore
+++ b/.npmignore
@@ -16,4 +16,4 @@ demo-build
 webpack.config.js
 
 #typescript sourcesc
-*.js.mapc
+*.js.map


### PR DESCRIPTION
I've removed the .ts files from npmignore, this will allow consumers to directly use the typescript files so that they can take advantage of things like treeshaking, and more importantly for my needs it should work with webpack.