### PR TITLE
Fix: Cannot find SourceMap 'ng2-tastr.js.map'

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,5 +14,3 @@ coverage
 demo
 demo-build
 webpack.config.js
-
-*.js.map


### PR DESCRIPTION
Fix for cannot find SourceMap issue. Details here: #25