### PR TITLE
angular cli setup difference

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Please update Angular 2 to latest version to avoid any unexpected issues.
     <script src="node_modules/ng2-toastr/bundles/ng2-toastr.min.js"></script>
     
     ```
+    
+    NOTE: If you are using angular-cli you do not need to include 'node_modules/ng2-toastr/bundles/ng2-toastr.min.js', since adding 'import {ToastModule} from 'ng2-toastr/ng2-toastr';' to your module file (below) will allow it to be autoloaded.
 
 3. Add ToastModule into your AppModule class. `app.module.ts` would look like this:
 


### PR DESCRIPTION
I added a sentence pointing out that when using angular cli toasts js file will be autoloaded since it is specified in app.module.ts, so doesn't need to be added. This will avoid any unnecessary console errors for those using angular cli.