### PR TITLE
Creates 'onClose' callback option. This is called when the createTime…

### DIFF
--- a/src/toast-manager.js
+++ b/src/toast-manager.js
@@ -50,10 +50,13 @@ var ToastsManager = (function () {
             resolve(_this.setupToast(toast, options));
         });
     };
-    ToastsManager.prototype.createTimeout = function (toast) {
+    ToastsManager.prototype.createTimeout = function (toast, options) {
         var _this = this;
         var task = setTimeout(function () {
             _this.clearToast(toast);
+            if(options && options.hasOwnProperty('onClose')){
+                options.onClose();
+            }
         }, toast.config.toastLife);
         return task.toString();
     };
@@ -69,7 +72,7 @@ var ToastsManager = (function () {
             }
         });
         if (toast.config.dismiss === 'auto') {
-            toast.timeoutId = this.createTimeout(toast);
+            toast.timeoutId = this.createTimeout(toast, options);
         }
         this.container.instance.addToast(toast);
         return toast;


### PR DESCRIPTION
This creates a lifecycle hook for the toastr automatically closing.

Creates 'onClose' callback option. This is called when the `ToastsManager.prototype.createTimeout` function clears the toast. I'm using this in my application for things such as navigating back to a different page after the toast has cleared. 

Example: click on 'Item' -> navigate to 'Item' page -> click 'delete item' -> `toastr.success('Item deleted.' , 'Success!',{onClose: function(){router.navigate('/ItemsPage');}});` -> toastr closes -> router navigates back to 'Items Page' since that Item was deleted. 

